### PR TITLE
Adds plausible

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,4 +37,5 @@
   {{ with resources.Get "css/index.css" | minify }}
   <link rel="stylesheet" href="{{ .RelPermalink }}">
   {{ end }}
+  <script defer data-domain="data-liberation-project.org" src="https://plausible.io/js/script.file-downloads.js"></script>
 </head>


### PR DESCRIPTION
I was reviewing the plausible install and it doesn't seem to be found. 
 /public gets overwritten during the Github actions deployment, so I think the previous PR just never even makes it to deployment. This is the only other file I can find that specifies the <head> element, so I am pretty sure this is supposed to be added here. 